### PR TITLE
Add basic tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,3 +18,9 @@ include = ["hello_world", "echo_bot"]
 [project.scripts]
 hello-world = "hello_world.__main__:main"
 echo-bot = "echo_bot.__main__:main"
+
+[project.optional-dependencies]
+test = ["pytest>=7", "pytest-asyncio"]
+
+[tool.pytest.ini_options]
+addopts = "-ra"

--- a/tests/test_echo_bot.py
+++ b/tests/test_echo_bot.py
@@ -1,0 +1,38 @@
+import pytest
+from echo_bot.__main__ import start, echo, _async_main
+
+
+class DummyUser:
+    def __init__(self, user_id: int = 1):
+        self.id = user_id
+
+
+class DummyMessage:
+    def __init__(self, text: str = "hi", user_id: int = 1):
+        self.text = text
+        self.from_user = DummyUser(user_id)
+        self.answered = None
+
+    async def answer(self, text: str):
+        self.answered = text
+
+
+@pytest.mark.asyncio
+async def test_start_sends_welcome_message():
+    msg = DummyMessage()
+    await start(msg)
+    assert msg.answered.startswith("Hello!"), msg.answered
+
+
+@pytest.mark.asyncio
+async def test_echo_replies_with_same_text():
+    msg = DummyMessage(text="echo")
+    await echo(msg)
+    assert msg.answered == "echo"
+
+
+@pytest.mark.asyncio
+async def test_async_main_requires_token(monkeypatch):
+    monkeypatch.delenv("BOT_TOKEN", raising=False)
+    with pytest.raises(RuntimeError):
+        await _async_main([])


### PR DESCRIPTION
## Summary
- add pytest and pytest-asyncio as optional deps
- configure pytest defaults
- test echo bot message handlers and CLI main

## Testing
- `uv run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856c4018f3c8330afe2c842cc154bef