### PR TITLE
Switch mini app to Vue via CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ It demonstrates how to deploy a simple HTML document using **GitHub Pages**.
 
 ### Local preview
 
-Open `docs/index.html` in your browser to test it locally. The page references
-`docs/styles.css` for its styling, so keep both files in the same directory.
+Open `docs/index.html` in your browser to test it locally. The page loads
+Vue from a CDN and references `docs/script.js` for its logic. Keep
+`docs/styles.css` in the same directory for styling.
 
 ### Deploy to GitHub Pages
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,11 +5,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mini App</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="https://unpkg.com/vue@3"></script>
 </head>
 <body>
-    <h1>Hello Daria</h1>
-    <p>This is a million dollars.</p>
-    <button onclick="changeTitle()">Получить деняк</button>
+    <div id="app">
+        <h1>{{ title }}</h1>
+        <p>This is a million dollars.</p>
+        <button @click="changeTitle">Получить деняк</button>
+    </div>
     <script src="script.js"></script>
 </body>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,3 +1,14 @@
-function changeTitle() {
-  document.querySelector('h1').textContent = 'С вас 1 миллион долларов';
-}
+const app = Vue.createApp({
+  data() {
+    return {
+      title: 'Hello Daria'
+    };
+  },
+  methods: {
+    changeTitle() {
+      this.title = 'С вас 1 миллион долларов';
+    }
+  }
+});
+
+app.mount('#app');


### PR DESCRIPTION
## Summary
- use Vue 3 from a CDN for the mini app
- add Vue-based logic to `script.js`
- update README instructions about local preview

## Testing
- `uv sync --extra test`
- `.venv/bin/pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685809fcc4e08330add3ed89ebd2f818